### PR TITLE
Fix register.ps1 parse error on PowerShell 5.1

### DIFF
--- a/register.ps1
+++ b/register.ps1
@@ -1,4 +1,4 @@
-$appPath = "$PSScriptRoot\GitHub Copilot Office Add-in.exe"
+﻿$appPath = "$PSScriptRoot\GitHub Copilot Office Add-in.exe"
 
 # Check if running from release (exe exists) or dev (manifest in root)
 if (Test-Path $appPath) {


### PR DESCRIPTION
Changes:
Add UTF-8 BOM (EF BB BF) to `register.ps1`.
Fixes #1

Description:
Adds a UTF-8 BOM to `register.ps1` so PowerShell 5.1 reads the file with the correct encoding.

Without the BOM, PowerShell 5.1 defaults to Windows-1252 encoding, which misinterprets the UTF-8 ✓ characters in the script. The third byte of each ✓ (0x93) maps to a left double quotation mark (") in Windows-1252, causing cascading parse errors:
```
The output stream for this command is already redirected.
The string is missing the terminator: ".
```