### PR TITLE
Add local file upload support

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -19,7 +19,7 @@ Install the following software:
 ### 1. Clone and Install Dependencies
 
 ```bash
-git clone https://github.com/patniko/github-copilot-office.git
+git clone https://github.com/<your-account>/github-copilot-office.git
 cd github-copilot-office
 npm install
 ```
@@ -61,6 +61,11 @@ You should see the GitHub Copilot icon appear in your system tray (Windows) or m
 <img width="358" height="352" alt="image" src="https://github.com/user-attachments/assets/e06d89a5-5fa8-4940-92b6-e60b04c1e5c7" />
 
 6. Have fun!
+
+### Local files
+- Use **Attach files** in the chat box to add local documents from your computer.
+- Pasted images still work as before.
+- For best results, use files that Copilot can read directly, such as text, PDF, Word, PowerPoint, spreadsheet, or code files.
 
 https://github.com/user-attachments/assets/5bb771d3-0bf6-4b7b-8e6c-757a085b3131
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,22 @@
 
 A Microsoft Office add-in that integrates GitHub Copilot into Word, Excel, and PowerPoint.
 
+## Fork / Reference
+
+This project is based on the open-source repository:
+
+- **Reference project:** `patniko/github-copilot-office`
+
+This fork keeps the original Office add-in idea and extends it for local use and publishing.
+
+## What changed in this fork
+
+- Added a safer local file upload flow for chat attachments
+- Kept image paste/upload support and made it work through a shared upload helper
+- Improved the PowerPoint/Office setup notes so the deployment flow is clearer
+- Added documentation that explains the reference project and the fork-specific changes
+- Tuned the local development flow so the add-in is easier to run and verify on Windows
+
 ## Getting Started
 
 **👉 See [GETTING_STARTED.md](GETTING_STARTED.md) for setup instructions.**

--- a/src/server-prod.js
+++ b/src/server-prod.js
@@ -8,6 +8,7 @@ const path = require('path');
 const fs = require('fs');
 const os = require('os');
 const { setupCopilotProxy } = require('./copilotProxy');
+const { saveUploadedFile } = require('./uploadFile');
 
 // Determine if we're running from pkg bundle
 const isPkg = typeof process.pkg !== 'undefined';
@@ -47,28 +48,26 @@ async function createServer() {
         return res.status(400).json({ error: 'Invalid image data' });
       }
 
-      const matches = dataUrl.match(/^data:image\/([a-zA-Z+]+);base64,(.+)$/);
-      if (!matches || matches.length !== 3) {
-        return res.status(400).json({ error: 'Invalid data URL format' });
+      if (!dataUrl.startsWith('data:image/')) {
+        return res.status(400).json({ error: 'Invalid image data' });
       }
 
-      const extension = matches[1] === 'svg+xml' ? 'svg' : matches[1];
-      const base64Data = matches[2];
-      const buffer = Buffer.from(base64Data, 'base64');
-
-      const tempDir = path.join(os.tmpdir(), 'copilot-office-images');
-      if (!fs.existsSync(tempDir)) {
-        fs.mkdirSync(tempDir, { recursive: true });
-      }
-
-      const filename = name || `image-${Date.now()}.${extension}`;
-      const filepath = path.join(tempDir, filename);
-      fs.writeFileSync(filepath, buffer);
-
-      res.json({ path: filepath, name: filename });
+      const saved = saveUploadedFile({ dataUrl, name, defaultExtension: '.png', tempSubdir: 'copilot-office-images' });
+      res.json({ path: saved.path, name: saved.name });
     } catch (error) {
       console.error('Upload error:', error);
       res.status(500).json({ error: error.message });
+    }
+  });
+
+  apiRouter.post('/upload-file', async (req, res) => {
+    try {
+      const { dataUrl, name } = req.body;
+      const saved = saveUploadedFile({ dataUrl, name });
+      res.json({ path: saved.path, name: saved.name, mimeType: saved.mimeType });
+    } catch (error) {
+      console.error('Upload error:', error);
+      res.status(400).json({ error: error.message });
     }
   });
 

--- a/src/server.js
+++ b/src/server.js
@@ -5,6 +5,7 @@ const path = require('path');
 const fs = require('fs');
 const os = require('os');
 const { setupCopilotProxy } = require('./copilotProxy');
+const { saveUploadedFile } = require('./uploadFile');
 
 async function createServer() {
   const app = express();
@@ -27,33 +28,26 @@ async function createServer() {
         return res.status(400).json({ error: 'Invalid image data' });
       }
 
-      // Extract base64 data
-      const matches = dataUrl.match(/^data:image\/([a-zA-Z+]+);base64,(.+)$/);
-      if (!matches || matches.length !== 3) {
-        return res.status(400).json({ error: 'Invalid data URL format' });
+      if (!dataUrl.startsWith('data:image/')) {
+        return res.status(400).json({ error: 'Invalid image data' });
       }
 
-      const extension = matches[1] === 'svg+xml' ? 'svg' : matches[1];
-      const base64Data = matches[2];
-      const buffer = Buffer.from(base64Data, 'base64');
-
-      // Create temp directory if it doesn't exist
-      const tempDir = path.join(os.tmpdir(), 'copilot-office-images');
-      if (!fs.existsSync(tempDir)) {
-        fs.mkdirSync(tempDir, { recursive: true });
-      }
-
-      // Generate unique filename
-      const filename = name || `image-${Date.now()}.${extension}`;
-      const filepath = path.join(tempDir, filename);
-
-      // Write file
-      fs.writeFileSync(filepath, buffer);
-
-      res.json({ path: filepath, name: filename });
+      const saved = saveUploadedFile({ dataUrl, name, defaultExtension: '.png', tempSubdir: 'copilot-office-images' });
+      res.json({ path: saved.path, name: saved.name });
     } catch (error) {
       console.error('Upload error:', error);
       res.status(500).json({ error: error.message });
+    }
+  });
+
+  apiRouter.post('/upload-file', async (req, res) => {
+    try {
+      const { dataUrl, name } = req.body;
+      const saved = saveUploadedFile({ dataUrl, name });
+      res.json({ path: saved.path, name: saved.name, mimeType: saved.mimeType });
+    } catch (error) {
+      console.error('Upload error:', error);
+      res.status(400).json({ error: error.message });
     }
   });
 
@@ -184,6 +178,5 @@ async function createServer() {
 }
 
 createServer().catch(console.error);
-
 
 

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -5,7 +5,7 @@ import {
   webDarkTheme,
   makeStyles,
 } from "@fluentui/react-components";
-import { ChatInput, ImageAttachment } from "./components/ChatInput";
+import { ChatInput, ImageAttachment, FileAttachment } from "./components/ChatInput";
 import { Message, MessageList, DebugEvent } from "./components/MessageList";
 import { HeaderBar, ModelType } from "./components/HeaderBar";
 import { SessionHistory } from "./components/SessionHistory";
@@ -58,6 +58,7 @@ export const App: React.FC = () => {
   const [messages, setMessages] = useState<Message[]>([]);
   const [inputValue, setInputValue] = useState("");
   const [images, setImages] = useState<ImageAttachment[]>([]);
+  const [files, setFiles] = useState<FileAttachment[]>([]);
   const [isTyping, setIsTyping] = useState(false);
   const [currentActivity, setCurrentActivity] = useState<string>("");
   const [streamingText, setStreamingText] = useState<string>("");
@@ -143,6 +144,7 @@ export const App: React.FC = () => {
     setMessages(restoredMessages || []);
     setInputValue("");
     setImages([]);
+    setFiles([]);
     setIsTyping(false);
     setCurrentActivity("");
     setStreamingText("");
@@ -239,7 +241,13 @@ Always use your tools to interact with the document. Never ask users to save, ex
     // Add user message with images
     setMessages((prev) => [...prev, {
       id: crypto.randomUUID(),
-      text: inputValue || (images.length > 0 ? `Sent ${images.length} image${images.length > 1 ? 's' : ''}` : ''),
+      text: inputValue || (
+        images.length > 0
+          ? `Sent ${images.length} image${images.length > 1 ? 's' : ''}`
+          : files.length > 0
+          ? `Sent ${files.length} file${files.length > 1 ? 's' : ''}`
+          : ''
+      ),
       sender: "user",
       timestamp: new Date(),
       images: images.length > 0 ? images.map(img => ({ dataUrl: img.dataUrl, name: img.name })) : undefined,
@@ -255,25 +263,26 @@ Always use your tools to interact with the document. Never ask users to save, ex
     setError("");
 
     try {
-      // Upload images to server and get file paths
+      // Upload local files to the server and get file paths
       const attachments: Array<{ type: "file", path: string, displayName?: string }> = [];
-      
+
+      const uploadItem = async (dataUrl: string, name: string, endpoint: string) => {
+        const response = await fetch(endpoint, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ dataUrl, name }),
+        });
+
+        if (!response.ok) {
+          throw new Error(`Failed to upload ${name}: ${response.statusText}`);
+        }
+
+        return response.json();
+      };
+
       for (const image of userImages) {
         try {
-          const response = await fetch('/api/upload-image', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ 
-              dataUrl: image.dataUrl,
-              name: image.name 
-            }),
-          });
-          
-          if (!response.ok) {
-            throw new Error(`Failed to upload image: ${response.statusText}`);
-          }
-          
-          const result = await response.json();
+          const result = await uploadItem(image.dataUrl, image.name, '/api/upload-image');
           attachments.push({
             type: "file",
             path: result.path,
@@ -282,6 +291,20 @@ Always use your tools to interact with the document. Never ask users to save, ex
         } catch (uploadError: any) {
           console.error('Image upload error:', uploadError);
           setError(`Failed to upload image: ${uploadError.message}`);
+        }
+      }
+
+      for (const file of files) {
+        try {
+          const result = await uploadItem(file.dataUrl, file.name, '/api/upload-file');
+          attachments.push({
+            type: "file",
+            path: result.path,
+            displayName: file.name,
+          });
+        } catch (uploadError: any) {
+          console.error('File upload error:', uploadError);
+          setError(`Failed to upload file: ${uploadError.message}`);
         }
       }
 
@@ -297,7 +320,7 @@ Always use your tools to interact with the document. Never ask users to save, ex
       let eventCount = 0;
       trafficStats.reset();
       for await (const event of session.query({ 
-        prompt: userInput || "Here are some images for you to analyze.",
+        prompt: userInput || (files.length > 0 ? "Here are some files for you to analyze." : "Here are some images for you to analyze."),
         attachments: attachments.length > 0 ? attachments : undefined
       })) {
         eventCount++;
@@ -433,6 +456,8 @@ Always use your tools to interact with the document. Never ask users to save, ex
           onSend={handleSend}
           images={images}
           onImagesChange={setImages}
+          files={files}
+          onFilesChange={setFiles}
         />
       </div>
     </FluentProvider>

--- a/src/ui/components/ChatInput.tsx
+++ b/src/ui/components/ChatInput.tsx
@@ -9,6 +9,14 @@ export interface ImageAttachment {
   name: string;
 }
 
+export interface FileAttachment {
+  id: string;
+  dataUrl: string;
+  name: string;
+  size: number;
+  type: string;
+}
+
 interface ChatInputProps {
   value: string;
   onChange: (value: string) => void;
@@ -17,6 +25,8 @@ interface ChatInputProps {
   disabled?: boolean;
   images?: ImageAttachment[];
   onImagesChange?: (images: ImageAttachment[]) => void;
+  files?: FileAttachment[];
+  onFilesChange?: (files: FileAttachment[]) => void;
 }
 
 const useStyles = makeStyles({
@@ -86,6 +96,54 @@ const useStyles = makeStyles({
       backgroundColor: "var(--colorNeutralBackground1Hover)",
     },
   },
+  filePickerRow: {
+    display: "flex",
+    gap: "8px",
+    alignItems: "center",
+    padding: "0 4px 4px",
+  },
+  filePreviewContainer: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "6px",
+    padding: "4px",
+  },
+  filePreview: {
+    display: "flex",
+    alignItems: "center",
+    gap: "8px",
+    padding: "6px 8px",
+    borderRadius: "4px",
+    border: "1px solid var(--colorNeutralStroke1)",
+    backgroundColor: "var(--colorNeutralBackground1)",
+  },
+  fileMeta: {
+    flex: 1,
+    minWidth: 0,
+    display: "flex",
+    flexDirection: "column",
+    gap: "2px",
+  },
+  fileName: {
+    fontSize: "12px",
+    fontWeight: 500,
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+  },
+  fileDetails: {
+    fontSize: "11px",
+    color: "var(--colorNeutralForeground3)",
+  },
+  fileRemoveButton: {
+    minWidth: "20px",
+    width: "20px",
+    height: "20px",
+    padding: "0",
+    backgroundColor: "transparent",
+    border: "none",
+    cursor: "pointer",
+  },
 });
 
 export const ChatInput: React.FC<ChatInputProps> = ({
@@ -94,9 +152,12 @@ export const ChatInput: React.FC<ChatInputProps> = ({
   onSend,
   images = [],
   onImagesChange,
+  files = [],
+  onFilesChange,
 }) => {
   const styles = useStyles();
   const inputRef = useRef<HTMLTextAreaElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     // Refocus when value becomes empty (after sending)
@@ -138,9 +199,41 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     }
   };
 
+  const readFileAsDataUrl = (file: File) =>
+    new Promise<string>((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(String(reader.result || ""));
+      reader.onerror = () => reject(reader.error || new Error("Failed to read file"));
+      reader.readAsDataURL(file);
+    });
+
+  const handleFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const selected = Array.from(e.target.files || []);
+    e.target.value = "";
+    if (!selected.length || !onFilesChange) return;
+
+    const uploaded = await Promise.all(
+      selected.map(async (file) => ({
+        id: crypto.randomUUID(),
+        dataUrl: await readFileAsDataUrl(file),
+        name: file.name,
+        size: file.size,
+        type: file.type,
+      })),
+    );
+
+    onFilesChange([...files, ...uploaded]);
+  };
+
   const handleRemoveImage = (id: string) => {
     if (onImagesChange) {
       onImagesChange(images.filter(img => img.id !== id));
+    }
+  };
+
+  const handleRemoveFile = (id: string) => {
+    if (onFilesChange) {
+      onFilesChange(files.filter(file => file.id !== id));
     }
   };
 
@@ -162,6 +255,43 @@ export const ChatInput: React.FC<ChatInputProps> = ({
           ))}
         </div>
       )}
+      {files.length > 0 && (
+        <div className={styles.filePreviewContainer}>
+          {files.map(file => (
+            <div key={file.id} className={styles.filePreview}>
+              <div className={styles.fileMeta}>
+                <span className={styles.fileName}>{file.name}</span>
+                <span className={styles.fileDetails}>
+                  {(file.type || "file") + " · " + Math.max(1, Math.round(file.size / 1024)) + " KB"}
+                </span>
+              </div>
+              <button
+                className={styles.fileRemoveButton}
+                onClick={() => handleRemoveFile(file.id)}
+                title="Remove file"
+              >
+                <Dismiss24Regular style={{ fontSize: '12px' }} />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+      <div className={styles.filePickerRow}>
+        <input
+          ref={fileInputRef}
+          type="file"
+          multiple
+          hidden
+          onChange={handleFileSelect}
+        />
+        <Button
+          appearance="subtle"
+          size="small"
+          onClick={() => fileInputRef.current?.click()}
+        >
+          Attach files
+        </Button>
+      </div>
       <Textarea
         ref={inputRef}
         className={styles.input}
@@ -169,7 +299,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
         onChange={(e, data) => onChange(data.value)}
         onKeyDown={handleKeyPress}
         onPaste={handlePaste}
-        placeholder="Type a message... (paste images with Ctrl+V)"
+        placeholder="Type a message... (paste images or attach files)"
         rows={2}
       />
       <Tooltip content="Send message" relationship="label">
@@ -177,7 +307,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
           appearance="primary"
           icon={<Send24Regular />}
           onClick={onSend}
-          disabled={!value.trim() && images.length === 0}
+          disabled={!value.trim() && images.length === 0 && files.length === 0}
           className={styles.sendButton}
         />
       </Tooltip>

--- a/src/uploadFile.js
+++ b/src/uploadFile.js
@@ -1,0 +1,73 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+function sanitizeFilename(name, fallback) {
+  const raw = path.basename(String(name || ''));
+  const safe = raw.replace(/[^a-zA-Z0-9._-]+/g, '_').replace(/^_+/, '');
+  return safe || fallback;
+}
+
+function extensionFromMimeType(mimeType) {
+  const map = {
+    'text/plain': '.txt',
+    'text/csv': '.csv',
+    'application/json': '.json',
+    'application/pdf': '.pdf',
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document': '.docx',
+    'application/vnd.openxmlformats-officedocument.presentationml.presentation': '.pptx',
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': '.xlsx',
+    'image/png': '.png',
+    'image/jpeg': '.jpg',
+    'image/jpg': '.jpg',
+    'image/gif': '.gif',
+    'image/webp': '.webp',
+    'image/svg+xml': '.svg',
+  };
+
+  return map[String(mimeType || '').toLowerCase()] || '';
+}
+
+function parseDataUrl(dataUrl) {
+  const match = String(dataUrl || '').match(/^data:([^;]+);base64,(.+)$/);
+  if (!match) {
+    throw new Error('Invalid data URL format');
+  }
+
+  return {
+    mimeType: match[1],
+    data: Buffer.from(match[2], 'base64'),
+  };
+}
+
+function saveUploadedFile({ dataUrl, name, defaultExtension = '.bin', tempSubdir = 'copilot-office-files' }) {
+  if (!dataUrl) {
+    throw new Error('Missing file data');
+  }
+
+  const { mimeType, data } = parseDataUrl(dataUrl);
+  const tempDir = path.join(os.tmpdir(), tempSubdir);
+
+  if (!fs.existsSync(tempDir)) {
+    fs.mkdirSync(tempDir, { recursive: true });
+  }
+
+  const safeName = sanitizeFilename(name, `upload-${Date.now()}`);
+  const ext = path.extname(safeName) || extensionFromMimeType(mimeType) || defaultExtension;
+  const base = path.basename(safeName, path.extname(safeName));
+  let finalName = `${base}${ext}`;
+  let filePath = path.join(tempDir, finalName);
+  let suffix = 1;
+
+  while (fs.existsSync(filePath)) {
+    finalName = `${base}-${suffix}${ext}`;
+    filePath = path.join(tempDir, finalName);
+    suffix += 1;
+  }
+
+  fs.writeFileSync(filePath, data);
+
+  return { path: filePath, name: finalName, mimeType };
+}
+
+module.exports = { saveUploadedFile };


### PR DESCRIPTION
This PR adds support for attaching local files in the Office add-in chat UI.\n\nWhat changed:\n- Added a shared upload helper for images and generic files\n- Added an Attach files picker in the chat input\n- Uploaded local files are saved to temp storage and passed to Copilot as attachments\n- Kept the existing image paste flow working\n- Documented the fork/reference and the new local file workflow\n\nReference project: patniko/github-copilot-office